### PR TITLE
release: repair production backend image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.vercel
+.env
+.env.*
+!.env.example
+**/node_modules
+**/.next
+**/dist
+**/coverage
+**/playwright-report
+**/test-results
+**/.turbo
+*.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,21 +2,18 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN npm install -g npm
+RUN apk add --no-cache openssl && corepack enable
+ENV HUSKY_SKIP_INSTALL=1
 
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
-COPY backend/package.json ./backend/
-COPY pnpm-lock.yaml ./backend/pnpm-lock.yaml
-COPY backend/tsconfig.json ./backend/tsconfig.json
+COPY .npmrc package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY backend/package.json ./backend/package.json
+RUN pnpm --filter backend... install --frozen-lockfile --prod=false --ignore-scripts
 
 COPY backend ./backend
-RUN HUSKY_SKIP_INSTALL=1 pnpm --filter ./backend... install --prod --ignore-scripts --no-frozen-lockfile
-RUN pnpm --filter ./backend... exec prisma generate && pnpm --filter ./backend... exec nest build
-
-RUN echo "prune skipped"
-
-RUN echo "deploy skipped"
+RUN pnpm --filter backend exec prisma generate
+RUN pnpm --filter backend run build
+RUN pnpm --filter backend deploy --prod /app/runtime
+RUN cd /app/runtime && /app/backend/node_modules/.bin/prisma generate --schema prisma/schema.prisma
 
 # RUNTIME
 FROM node:20-alpine AS runtime
@@ -24,7 +21,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=4000
 EXPOSE 4000
-COPY --from=build --chown=node:node /app/backend/dist ./dist
+RUN apk add --no-cache openssl
+COPY --from=build --chown=node:node /app/runtime ./
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD node -e "const http=require('http');const port=process.env.PORT||4000;const req=http.get({host:'127.0.0.1',port,path:'/api/health/live',timeout:4000},res=>process.exit(res.statusCode===200?0:1));req.on('error',()=>process.exit(1));req.on('timeout',()=>{req.destroy();process.exit(1);});"


### PR DESCRIPTION
## Zakres
- buduje backend z pełnymi zależnościami narzędziowymi
- pakuje wyłącznie runtime dependencies przez `pnpm deploy --prod`
- generuje Prisma Client w obrazie runtime i instaluje OpenSSL
- wyklucza artefakty lokalne oraz pliki środowiskowe z kontekstu Docker

## Weryfikacja
- `corepack pnpm check`
- lokalny build obrazu backendu
- runtime smoke Express + PrismaClient
- CI/CodeQL/Vercel Preview zielone na PR #155