### PR TITLE
Release reconciled worktree to main

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,5 +29,5 @@ Create `frontend/.env.local` from [`frontend/.env.example`](./.env.example).
 - Contact form and chat submit through same-origin `/api/contact` and `/api/chat` routes.
 - Both proxy routes require JSON, stream at most 16 KiB, and return generic upstream errors.
 - Dynamic pages receive a per-request CSP nonce; scripts no longer depend on `unsafe-inline`.
-- The security boundary currently uses the compatible `src/middleware.ts` convention because Vercel CLI 58.x expects its traced middleware artifact; migrate back to `src/proxy.ts` only after `vercel build` accepts the Next.js 16 proxy output.
+- The security boundary uses the Next.js 16 `src/proxy.ts` convention; the production build must retain its traced proxy artifact and the per-request nonce headers.
 - No third-party analytics is loaded. Contact data is retained for at most 90 days by default; chat text is sent to OpenAI and its application session is retained in memory for at most 24 hours by default.


### PR DESCRIPTION
## Release

Promotes the fully reconciled `dev` tree to `main` after auditing and consolidating the original dirty worktree.

All functional hardening was already present on `dev`; the only new tree change corrects the frontend production documentation to describe the active Next.js 16 `src/proxy.ts` nonce boundary. Stale local Docker, CI, CSP, dependency, and middleware variants were deliberately not reintroduced.

## Verification

- Full local `corepack pnpm check` passed.
- Backend unit: 40 suites / 152 tests.
- Frontend unit: 12 files / 64 tests.
- BDD: 7 scenarios / 27 steps.
- Backend E2E: 11 suites / 34 tests.
- Browser E2E: 3 tests.
- PR CI, CodeQL, release-flow guard, build, E2E, and Vercel preview passed.
- Production dependency audit reports no known vulnerabilities.

This is a documentation-only final delta, so a new red-green TDD loop is not applicable; the complete regression gate was rerun.
