### PR TITLE
[codex] Align portfolio claims and accessibility evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains:
 - **Contact Flow**: persistence-backed outbox semantics, where a submission is considered successful once it is stored and accepted for asynchronous provider delivery; `resend` mode adds idempotent submission plus signed webhook confirmation
 - **File Storage**: AWS S3 integration for portfolio assets
 - **Internationalization**: locale-aware frontend routes and translations
-- **Testing**: backend/frontend unit tests, executable Cucumber BDD scenarios, backend transport E2E, and Playwright browser E2E
+- **Testing**: backend/frontend unit tests, executable Cucumber BDD scenarios, backend transport E2E, and Playwright browser E2E with automated WCAG A/AA checks
 - **Deployment Assets**: Docker and CI workflow definitions
 
 ## Architecture Overview
@@ -382,7 +382,7 @@ Test ownership is intentionally split to avoid duplicate scenarios:
 - executable BDD owns visitor-facing contact and chat behavior;
 - backend E2E owns transport and infrastructure contracts such as GraphQL,
   authorization, throttling, signed proxy metadata, health, and webhooks;
-- Playwright owns browser flows, accessibility, and SEO behavior.
+- Playwright owns browser flows, SEO behavior, keyboard interactions, and automated WCAG A/AA scans with axe-core.
 
 Playwright owns isolated local ports `3100` (frontend) and `4100` (backend) and
 does not reuse unrelated development servers. Override them with

--- a/backend/scripts/portfolio.data.json
+++ b/backend/scripts/portfolio.data.json
@@ -25,7 +25,6 @@
       "NextJS",
       "React",
       "JavaScript",
-      "React",
       "TypeScript",
       "MDX",
       "Cypress",
@@ -48,8 +47,8 @@
     "title": "Mazowieści",
     "slug": "mazowiesci",
     "href": "https://mazowiesci.pl",
-    "desc": "Przeprowadziłem pełną migrację serwisu informacyjnego z WIX do WordPress. Zautomatyzowałem ekstrakcję artykułów z pomocą Python (Scrapy) i zaimportowałem treści do bazy danych WordPress. Stworzyłem niestandardowe skrypty PHP do integracji danych, wdrożyłem politykę optymalizacji SEO, przebudowałem menu i system tagów. Zoptymalizowałem szybkość strony i poprawiłem jej pozycję w Google.",
-    "desc_en": "I have conducted a full migration of the WIX news service to WordPress. I automated the extraction of articles with the help of Python (Scrapy) and imported content into the WordPress database. I created custom PHP scripts for data integration, implemented an SEO optimization policy, rebuilt the menu and tag system. I optimized the speed of the page and improved its position on Google.",
+    "desc": "Przeprowadziłem migrację serwisu informacyjnego z Wix do WordPress. Zautomatyzowałem ekstrakcję artykułów w Pythonie (Scrapy), przygotowałem import treści oraz skrypty PHP do integracji danych, a także przebudowałem menu, tagi i techniczne elementy SEO.",
+    "desc_en": "I migrated a news website from Wix to WordPress. I automated article extraction in Python (Scrapy), prepared content imports and PHP data-integration scripts, and rebuilt the menu, tags and technical SEO elements.",
     "tags": ["WordPress", "PHP", "Python", "HTML", "CSS", "SEO"],
     "img": "https://wizytowka.s3.eu-north-1.amazonaws.com/mazo.png",
     "isLogo": true,
@@ -63,11 +62,11 @@
     "title": "Strona Wizytówka",
     "slug": "strona-wizytowka",
     "href": "https://pietrzakprzemyslaw.pl",
-    "desc": "One-pager w Next.js z Tailwind i Sass.",
-    "desc_en": "One-pager in Next.js with Tailwind and Sass.",
+    "desc": "Dwujęzyczne portfolio w Next.js i React z backendem NestJS, REST/GraphQL, formularzem kontaktowym z outboxem oraz chatbotem korzystającym z OpenAI.",
+    "desc_en": "A bilingual Next.js and React portfolio with a NestJS backend, REST/GraphQL APIs, an outbox-backed contact flow and an OpenAI-powered chatbot.",
     "tags": [
       "NextJS",
-      "JavaScript",
+      "React",
       "NestJS",
       "TypeScript",
       "Tailwind",
@@ -77,8 +76,7 @@
       "MongoDB",
       "REST API",
       "GraphQL API",
-      "Docker",
-      "Kubernetes"
+      "Docker"
     ],
     "img": "https://wizytowka.s3.eu-north-1.amazonaws.com/PP-2-JPG-01.webp",
     "isLogo": true,
@@ -116,7 +114,7 @@
     "dateFrom": "2025-12-01",
     "dateTo": null,
     "order": 6,
-    "status": "published"
+    "status": "draft"
   },
   {
     "title": "AI-enhanced Eisenhower Matrix",
@@ -166,7 +164,7 @@
     "dateFrom": "2025-11-01",
     "dateTo": null,
     "order": 8,
-    "status": "published"
+    "status": "draft"
   },
   {
     "title": "LegatoDesk Shop™",
@@ -180,44 +178,45 @@
     "dateFrom": "2025-11-01",
     "dateTo": null,
     "order": 9,
-    "status": "published"
+    "status": "draft"
   },
   {
     "title": "ORGON™ – System HR",
     "slug": "my-hr-vision-system",
-    "desc": "Modułowy system HR tworzony w Symfony, Twig i MySQL z architekturą mikroserwisową.",
-    "desc_en": "Modular HR management system built with Symfony, Twig and MySQL, using a microservice architecture.",
+    "desc": "Modułowy system HR rozwijany jako monorepo z API i workerem Symfony, interfejsem Next.js, narzędziami Go oraz PostgreSQL.",
+    "desc_en": "A modular HR system developed as a monorepo with a Symfony API and worker, a Next.js interface, Go tooling and PostgreSQL.",
     "tags": [
       "PHP",
-      "MySQL",
       "Symfony",
-      "Twig",
+      "NextJS",
+      "React",
+      "TypeScript",
+      "Go",
+      "PostgreSQL",
       "Docker",
-      "Trivy",
-      "Kubernetes",
-      "Microservices"
+      "Trivy"
     ],
     "img": "https://wizytowka.s3.eu-north-1.amazonaws.com/Logo+PP+Legal+Solutions+-+3.png",
     "isLogo": true,
-    "category": "services, mobile-app, ai",
+    "category": "web-app, services",
     "dateFrom": "2025-09-01",
     "dateTo": "2025-12-31",
     "order": 10,
-    "status": "published"
+    "status": "draft"
   },
   {
     "title": "ORGON™ – Landing Page",
     "slug": "my-hr-vision-landing",
-    "desc": "Landing page sprzedażowy dla systemu ORGON™.",
-    "desc_en": "Sales landing page for the ORGON™ system.",
-    "tags": ["NextJS", "JavaScript", "NestJS", "TypeScript", "CSS", "Trivy"],
+    "desc": "Landing produktowy ORGON™ utrzymywany w kanonicznej aplikacji Next.js.",
+    "desc_en": "The ORGON™ product landing page maintained in the canonical Next.js application.",
+    "tags": ["NextJS", "React", "TypeScript", "Tailwind", "Trivy"],
     "img": "https://wizytowka.s3.eu-north-1.amazonaws.com/Logo+PP+Legal+Solutions+-+3.png",
     "isLogo": true,
     "category": "landing",
     "dateFrom": "2025-11-01",
     "dateTo": "2025-11-30",
     "order": 11,
-    "status": "published"
+    "status": "draft"
   },
   {
     "title": "PP Solutions P.S.A. – Website & Maintenance",

--- a/backend/test/portfolio-file.spec.ts
+++ b/backend/test/portfolio-file.spec.ts
@@ -20,18 +20,34 @@ describe('portfolio file sync helpers', () => {
 
   it('keeps published portfolio links and the business-card stack factual', () => {
     const items = portfolioData as PortfolioFileItem[];
+    const publishedItems = items.filter((item) => item.status === 'published');
     const businessCard = items.find((item) => item.slug === 'strona-wizytowka');
+    const orgonSystem = items.find((item) => item.slug === 'my-hr-vision-system');
     const ppSolutions = items.find((item) => item.slug === 'pp-solutions-website');
 
-    expect(items.filter((item) => item.status === 'published')).not.toEqual(
-      expect.arrayContaining([expect.objectContaining({ href: '' })]),
-    );
+    expect(
+      publishedItems.every(
+        (item) => Boolean(item.href?.trim()) || Boolean(item.repoUrl?.trim()),
+      ),
+    ).toBe(true);
     expect(ppSolutions?.repoUrl).toBeUndefined();
     expect(businessCard?.tags).toEqual(
       expect.arrayContaining(['NextJS', 'NestJS', 'Prisma', 'MongoDB']),
     );
     expect(businessCard?.tags).not.toEqual(
-      expect.arrayContaining(['PostgreSQL', 'MUI', 'Microservices']),
+      expect.arrayContaining([
+        'PostgreSQL',
+        'MUI',
+        'Microservices',
+        'Kubernetes',
+      ]),
+    );
+    expect(orgonSystem?.status).toBe('draft');
+    expect(orgonSystem?.tags).toEqual(
+      expect.arrayContaining(['Symfony', 'NextJS', 'Go', 'PostgreSQL']),
+    );
+    expect(orgonSystem?.tags).not.toEqual(
+      expect.arrayContaining(['MySQL', 'Twig', 'Kubernetes', 'Microservices']),
     );
   });
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,7 +10,7 @@ Next.js 16 frontend for the portfolio site. It serves the locale-aware onepager,
 - `pnpm lint` - ESLint and Prettier check
 - `pnpm typecheck` - TypeScript check
 - `pnpm test` - Vitest unit tests
-- `pnpm test:e2e` - Playwright browser tests
+- `pnpm test:e2e` - Playwright browser tests, including axe-core WCAG A/AA checks
 
 ## Environment
 

--- a/frontend/e2e/accessibility-seo.spec.ts
+++ b/frontend/e2e/accessibility-seo.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
 
 const appBaseUrl = process.env.E2E_BASE_URL ?? '';
 
@@ -45,4 +46,22 @@ test('mobile navigation exposes its expanded state', async ({ page }) => {
   await menuButton.click();
   await expect(menuButton).toHaveAttribute('aria-expanded', 'true');
   await expect(page.locator('#mobile-navigation')).toBeVisible();
+});
+
+test('localized desktop and mobile pages have no automated WCAG A/AA violations', async ({
+  page,
+}) => {
+  for (const scenario of [
+    { locale: 'en', width: 1440, height: 900 },
+    { locale: 'pl', width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize({ width: scenario.width, height: scenario.height });
+    await page.goto(`${appBaseUrl}/${scenario.locale}`);
+
+    const scan = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    expect(scan.violations, `${scenario.locale} ${scenario.width}px`).toEqual([]);
+  }
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/eslintrc": "^3.3.5",
     "@graphql-codegen/cli": "^6.2.1",
     "@graphql-codegen/client-preset": "^4.2.1",

--- a/frontend/src/app/[locale]/layout.test.ts
+++ b/frontend/src/app/[locale]/layout.test.ts
@@ -14,4 +14,12 @@ describe('localized metadata', () => {
       },
     });
   });
+
+  it.each(['en', 'pl'])('keeps public positioning factual for %s', async (locale) => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ locale }) });
+    const description = String(metadata.description);
+
+    expect(description).toContain('TypeScript');
+    expect(description).not.toMatch(/offline AI|Kubernetes/i);
+  });
 });

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -25,11 +25,11 @@ export async function generateMetadata({
 
   return {
     title: isPolish
-      ? 'Przemysław Pietrzak - Full Stack Developer | Next.js, PHP, AI'
-      : 'IT Business Card - Przemysław Pietrzak',
+      ? 'Przemysław Pietrzak - Full-stack TypeScript Developer'
+      : 'Przemysław Pietrzak - Full-stack TypeScript Developer',
     description: isPolish
-      ? 'Full Stack Web Developer specjalizujący się w nowoczesnych aplikacjach webowych (Next.js, Laravel, Node) oraz rozwiązaniach opartych na AI.'
-      : 'PHP & Next.js Web Developer specializing in modern web applications, Laravel, and offline AI systems.',
+      ? 'Tworzę aplikacje webowe w TypeScript, React/Next.js i Node/NestJS oraz rozwijam projekty PHP/Symfony.'
+      : 'I build web applications with TypeScript, React/Next.js and Node/NestJS, and maintain PHP/Symfony projects.',
     keywords: isPolish
       ? 'Przemysław Pietrzak, Full Stack Developer, Next.js, React, TypeScript, PHP, Laravel, Node.js, AI, Web Applications, Portfolio'
       : 'Next.js, PHP, Laravel, Web Developer, React, Prisma, Docker, AI, Web Applications, Przemysław Pietrzak',
@@ -47,11 +47,11 @@ export async function generateMetadata({
     },
     openGraph: {
       title: isPolish
-        ? 'Przemysław Pietrzak - Full Stack Developer'
-        : 'IT Business Card - Przemysław Pietrzak',
+        ? 'Przemysław Pietrzak - Full-stack TypeScript Developer'
+        : 'Przemysław Pietrzak - Full-stack TypeScript Developer',
       description: isPolish
-        ? 'Full Stack Web Developer specjalizujący się w nowoczesnych aplikacjach webowych (Next.js, Laravel, Node) oraz rozwiązaniach opartych na AI.'
-        : 'PHP & Next.js Web Developer specializing in modern web applications, Laravel, and offline AI systems.',
+        ? 'Tworzę aplikacje webowe w TypeScript, React/Next.js i Node/NestJS oraz rozwijam projekty PHP/Symfony.'
+        : 'I build web applications with TypeScript, React/Next.js and Node/NestJS, and maintain PHP/Symfony projects.',
       url: `${siteUrl}/${locale}`,
       siteName: isPolish ? 'Portfolio Przemysława Pietrzaka' : 'Przemysław Pietrzak Portfolio',
       images: [
@@ -70,11 +70,11 @@ export async function generateMetadata({
     twitter: {
       card: 'summary_large_image',
       title: isPolish
-        ? 'Przemysław Pietrzak - Full Stack Developer'
-        : 'IT Business Card - Przemysław Pietrzak',
+        ? 'Przemysław Pietrzak - Full-stack TypeScript Developer'
+        : 'Przemysław Pietrzak - Full-stack TypeScript Developer',
       description: isPolish
-        ? 'Full Stack Web Developer specjalizujący się w nowoczesnych aplikacjach webowych (Next.js, Laravel, Node) oraz rozwiązaniach opartych na AI.'
-        : 'PHP & Next.js Web Developer specializing in modern web applications, Laravel, and offline AI systems.',
+        ? 'Tworzę aplikacje webowe w TypeScript, React/Next.js i Node/NestJS oraz rozwijam projekty PHP/Symfony.'
+        : 'I build web applications with TypeScript, React/Next.js and Node/NestJS, and maintain PHP/Symfony projects.',
       images: ['/images/PP-2-JPG-01.webp'],
       creator: '@przemekp95',
     },

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -152,11 +152,11 @@ export default async function OnePager({ params }: { params: Promise<{ locale: s
     '@context': 'https://schema.org',
     '@type': 'Person',
     name: 'Przemysław Pietrzak',
-    jobTitle: locale === 'en' ? 'Full Stack Web Developer' : 'Full Stack Web Developer',
+    jobTitle: 'Full-stack TypeScript Developer',
     description:
       locale === 'en'
-        ? 'I build modern web applications (Next.js, Laravel, Node) and design solutions based on SQL, NoSQL and API (REST, GraphQL). I combine legal knowledge with technology.'
-        : 'Buduję nowoczesne aplikacje webowe (Next.js, Laravel, Node) i projektuję rozwiązania oparte na SQL, NoSQL oraz API (REST, GraphQL). Łączę wiedzę prawniczą z technologią.',
+        ? 'I build web applications with TypeScript, React/Next.js and Node/NestJS, and maintain PHP/Symfony projects.'
+        : 'Tworzę aplikacje webowe w TypeScript, React/Next.js i Node/NestJS oraz rozwijam projekty PHP/Symfony.',
     knowsAbout: [
       'Next.js',
       'React',
@@ -169,11 +169,10 @@ export default async function OnePager({ params }: { params: Promise<{ locale: s
       'REST API',
       'GraphQL',
       'Docker',
-      'Kubernetes',
     ],
     hasOccupation: {
       '@type': 'Occupation',
-      name: 'Full Stack Developer',
+      name: 'Full-stack TypeScript Developer',
       occupationalCategory: 'Software Development',
     },
     sameAs: [
@@ -341,7 +340,7 @@ export default async function OnePager({ params }: { params: Promise<{ locale: s
                       ))}
                   </div>
                 ) : (
-                  <p className="text-center text-gray-500">
+                  <p className="text-center text-gray-300">
                     {locale === 'en' ? 'No skills data available' : 'Brak danych o umiejętnościach'}
                   </p>
                 )}
@@ -368,7 +367,7 @@ export default async function OnePager({ params }: { params: Promise<{ locale: s
 
         <section id="contact" className="py-24 bg-transparent text-white">
           <div className="mx-auto max-w-6xl px-4">
-            <h2 className="section-title text-center text-4xl md:text-5xl font-extrabold tracking-tight text-white">
+            <h2 className="text-center text-4xl md:text-5xl font-extrabold tracking-tight text-white">
               {t('contact.title')}
             </h2>
             <div className="mt-10 flex justify-center">

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -30,9 +30,9 @@ function resolveHtmlLocale(rawLocale: string | null): string {
 }
 
 export const metadata: Metadata = {
-  title: 'Przemysław Pietrzak - Next.js & PHP Web Developer',
+  title: 'Przemysław Pietrzak - Full-stack TypeScript Developer',
   description:
-    'I build modern web applications (Next.js, Laravel, Node) and design solutions based on SQL, NoSQL and API (REST, GraphQL). I combine legal knowledge with technology.',
+    'I build web applications with TypeScript, React/Next.js and Node/NestJS, and maintain PHP/Symfony projects.',
   keywords:
     'Next.js, PHP, Laravel, Node.js, React, TypeScript, Web Developer, Full Stack Developer',
   authors: [{ name: 'Przemysław Pietrzak' }],
@@ -48,9 +48,9 @@ export const metadata: Metadata = {
     canonical: 'https://pietrzakprzemyslaw.pl',
   },
   openGraph: {
-    title: 'Przemysław Pietrzak - Next.js & PHP Web Developer',
+    title: 'Przemysław Pietrzak - Full-stack TypeScript Developer',
     description:
-      'I build modern web applications (Next.js, Laravel, Node) and design solutions based on SQL, NoSQL and API (REST, GraphQL). I combine legal knowledge with technology.',
+      'I build web applications with TypeScript, React/Next.js and Node/NestJS, and maintain PHP/Symfony projects.',
 
     url: 'https://pietrzakprzemyslaw.pl',
     siteName: 'Przemyslaw Pietrzak - Developer Portfolio',
@@ -79,9 +79,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Przemysław Pietrzak - Next.js & PHP Web Developer',
+    title: 'Przemysław Pietrzak - Full-stack TypeScript Developer',
     description:
-      'I build modern web applications (Next.js, Laravel, Node) and design solutions based on SQL, NoSQL and API (REST, GraphQL). I combine legal knowledge with technology.',
+      'I build web applications with TypeScript, React/Next.js and Node/NestJS, and maintain PHP/Symfony projects.',
     creator: '@przemekp95',
   },
   verification: googleSiteVerification

--- a/frontend/src/i18n/messages/en.json
+++ b/frontend/src/i18n/messages/en.json
@@ -9,8 +9,8 @@
     "contactMe": "Contact me"
   },
   "hero": {
-    "title": "Next.js & PHP Web Developer",
-    "description": "I build modern web applications (Next.js, Laravel, Node) and design solutions based on SQL, NoSQL and API (REST, GraphQL). I combine legal knowledge with technology.",
+    "title": "Full-stack TypeScript Developer",
+    "description": "I build web applications with TypeScript, React/Next.js and Node/NestJS, and maintain PHP projects. I work with REST, GraphQL, SQL and MongoDB.",
     "viewProjects": "View projects",
     "contactMe": "Contact me"
   },
@@ -24,12 +24,12 @@
   },
   "about": {
     "title": "About me",
-    "description": "I am a developer combining law and technology. I build modern web applications in Next.js, Laravel and Symfony, design backends in Node/NestJS using Prisma and SQL databases (MySQL, PostgreSQL) and NoSQL (MongoDB). I create REST API and GraphQL API, deploy projects in CI/CD architecture (Docker, GitHub Actions, Passenger on Cyber_Folks), and also develop Kubernetes-based environments and integrate them with cloud services like Render or Vercel. I use automated tests (Jest, React Testing Library, Playwright, PHPUnit) in frontend and backend projects.",
+    "description": "I am a developer combining law and technology. I build applications with React/Next.js and Node/NestJS, and maintain PHP projects in Laravel and Symfony. I work with REST, GraphQL, PostgreSQL, MySQL and MongoDB, and automate testing and delivery with Docker and GitHub Actions.",
     "techStack": "Technology stack",
     "frontend": "Frontend: Next.js / React / Tailwind / SCSS / JavaScript, TypeScript",
     "backend": "Backend: Laravel / Symfony / PHP, Node / NestJS (Typescript)",
     "databases": "Databases: Prisma / SQL (MySQL, PostgreSQL), MongoDB / NoSQL",
-    "devops": "DevOps: Docker / GitHub Actions / Kubernetes / Passenger (Cyber_Folks) / Render / Vercel / AWS"
+    "devops": "Delivery: Docker / GitHub Actions / Passenger (Cyber_Folks) / Render / Vercel / AWS"
   },
   "contact": {
     "title": "Contact",

--- a/frontend/src/i18n/messages/pl.json
+++ b/frontend/src/i18n/messages/pl.json
@@ -9,19 +9,19 @@
     "contactMe": "Napisz do mnie"
   },
   "hero": {
-    "title": "Next.js & PHP Web Developer",
-    "description": "Buduję nowoczesne aplikacje webowe (Next.js, Laravel, Node) i projektuję rozwiązania oparte na SQL, NoSQL oraz API (REST, GraphQL). Łączę wiedzę prawniczą z technologią.",
+    "title": "Full-stack TypeScript Developer",
+    "description": "Tworzę aplikacje webowe w TypeScript, React/Next.js i Node/NestJS oraz rozwijam projekty PHP. Pracuję z REST, GraphQL, SQL i MongoDB.",
     "viewProjects": "Zobacz projekty",
     "contactMe": "Skontaktuj się"
   },
   "about": {
     "title": "O mnie",
-    "description": "Jestem developerem łączącym prawo i technologię. Buduję nowoczesne aplikacje webowe w Next.js, Laravel i Symfony, projektuję backendy w Node/NestJS z użyciem Prisma oraz baz danych SQL (MySQL, PostgreSQL) i NoSQL (MongoDB). Tworzę REST API i GraphQL API, wdrażam projekty w architekturze CI/CD (Docker, GitHub Actions, Passenger na Cyber_Folks), a także rozwijam środowiska oparte na Kubernetes i integruję je z usługami chmurowymi jak Render czy Vercel. Stosuję testy automatyczne (Jest, React Testing Library, Playwright, PHPUnit) w projektach frontendowych i backendowych.",
+    "description": "Jestem developerem łączącym prawo i technologię. Buduję aplikacje w React/Next.js i Node/NestJS, a także rozwijam projekty PHP w Laravelu i Symfony. Pracuję z REST, GraphQL, PostgreSQL, MySQL i MongoDB oraz automatyzuję testy i dostarczanie zmian za pomocą Dockera i GitHub Actions.",
     "techStack": "Stack technologiczny",
     "frontend": "Frontend: Next.js / React / Tailwind / SCSS / JavaScript, TypeScript",
     "backend": "Backend: Laravel / Symfony / PHP, Node / NestJS (Typescript)",
     "databases": "Bazy danych: Prisma / SQL (MySQL, PostgreSQL), MongoDB / NoSQL",
-    "devops": "DevOps: Docker / GitHub Actions / Kubernetes / Passenger (Cyber_Folks) / Render / Vercel / AWS"
+    "devops": "Dostarczanie: Docker / GitHub Actions / Passenger (Cyber_Folks) / Render / Vercel / AWS"
   },
   "contact": {
     "title": "Kontakt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.58.2)
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
@@ -733,6 +736,11 @@ packages:
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -4190,6 +4198,10 @@ packages:
 
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
+    engines: {node: '>=4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
   axobject-query@4.1.0:
@@ -9210,6 +9222,11 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@axe-core/playwright@4.12.1(playwright-core@1.58.2)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.58.2
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -13010,6 +13027,8 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.1: {}
+
+  axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
## Summary

- align public positioning and project stacks with code-backed evidence
- keep ORGON and LegatoDesk entries without public proof as drafts until a working public reference exists
- add axe-core WCAG A/AA browser coverage and fix the contrast regressions it exposed
- document the stronger accessibility gate

## Why

The public portfolio mixed current implementation details with stale or unsupported claims. ORGON still described an old Twig/MySQL/microservices topology, the business-card project claimed removed Kubernetes infrastructure, and the English metadata described the OpenAI-backed chat as offline AI. Published projects without a public live URL or public repository also lacked recruiter-verifiable evidence.

## Checks

- [x] Test-first regressions reproduced unsupported published items and stale metadata
- [x] Axe test first reproduced two WCAG color-contrast violations
- [x] `corepack pnpm check`
- [x] 152 backend unit tests
- [x] 66 frontend unit tests
- [x] 7 Cucumber scenarios / 27 steps
- [x] 34 backend E2E tests
- [x] 4 Playwright tests including desktop/mobile WCAG A/AA scans
- [x] `corepack pnpm audit --audit-level high` — no known vulnerabilities

No production portfolio synchronization or deployment is included in this PR.