### PR TITLE
Release production contrast fix

### DIFF
--- a/frontend/src/components/PortfolioSection.tsx
+++ b/frontend/src/components/PortfolioSection.tsx
@@ -296,11 +296,11 @@ export default function PortfolioSection({
                       )}
                     </motion.h3>
 
-                    <p className="mt-2 text-sm text-black dark:text-gray-400">{displayDesc}</p>
+                    <p className="mt-2 text-sm text-slate-700">{displayDesc}</p>
 
                     {p.repoUrl?.trim() && (
                       <div className="mt-4">
-                        <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-gray-500">
+                        <div className="text-xs uppercase tracking-wide text-slate-700">
                           {t('repository')}
                         </div>
                         <a

--- a/frontend/src/components/SkillBar.tsx
+++ b/frontend/src/components/SkillBar.tsx
@@ -19,19 +19,19 @@ interface SkillBarProps {
 const colorMap = {
   frontEnd: {
     indicator: 'bg-indigo-500',
-    text: 'text-indigo-600',
+    text: 'text-indigo-300',
   },
   backEnd: {
     indicator: 'bg-purple-500',
-    text: 'text-purple-600',
+    text: 'text-purple-300',
   },
   database: {
     indicator: 'bg-cyan-500',
-    text: 'text-cyan-600',
+    text: 'text-cyan-300',
   },
   devops: {
     indicator: 'bg-emerald-500',
-    text: 'text-emerald-600',
+    text: 'text-emerald-300',
   },
 } as const;
 
@@ -93,7 +93,7 @@ export function SkillBar({ skill, locale = 'pl', maxProjects }: SkillBarProps) {
           className={`h-full ${colors.indicator} rounded-full`}
         />
       </Progress.Root>
-      <div className="text-xs text-black dark:text-slate-500 mt-1">
+      <div className="text-xs text-slate-300 mt-1">
         {locale === 'en'
           ? `Used in ${pluralizeProjects(skill.projectCount, locale).toLowerCase()}`
           : pluralizeProjects(skill.projectCount, locale)}

--- a/frontend/src/components/__tests__/PortfolioSection.test.tsx
+++ b/frontend/src/components/__tests__/PortfolioSection.test.tsx
@@ -56,5 +56,6 @@ describe('PortfolioSection', () => {
     expect(heading).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Private project' })).not.toBeInTheDocument();
     expect(heading.querySelector('a')).not.toBeInTheDocument();
+    expect(screen.getByText('Private project description')).toHaveClass('text-slate-700');
   });
 });

--- a/frontend/src/components/__tests__/SkillBar.test.tsx
+++ b/frontend/src/components/__tests__/SkillBar.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SkillBar } from '../SkillBar';
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_target, tag: string) =>
+        ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
+          const Component = tag as keyof React.JSX.IntrinsicElements;
+          const domProps = Object.fromEntries(
+            Object.entries(props).filter(
+              ([key]) => !['initial', 'animate', 'transition'].includes(key)
+            )
+          );
+          return <Component {...domProps}>{children}</Component>;
+        },
+    }
+  ),
+}));
+
+describe('SkillBar', () => {
+  it('uses high-contrast labels on the dark skills section', () => {
+    render(
+      <SkillBar
+        locale="en"
+        maxProjects={6}
+        skill={{
+          id: 'typescript',
+          name: 'TypeScript',
+          projectCount: 6,
+          category: 'frontEnd',
+        }}
+      />
+    );
+
+    expect(screen.getByText('6 projects')).toHaveClass('text-indigo-300');
+    expect(screen.getByText('Used in 6 projects')).toHaveClass('text-slate-300');
+  });
+});


### PR DESCRIPTION
## Zakres
- publikuje poprawkę WCAG z PR #163
- usuwa potwierdzone na produkcji naruszenia kontrastu kart portfolio i etykiet umiejętności

## Weryfikacja
- frontend lint i typecheck
- testy regresyjne komponentów
- production build
- pełne CI PR #163: unit, build, backend E2E, browser E2E, CodeQL i Vercel Preview zielone

Po deployu zostanie wykonany świeży axe WCAG A/AA na produkcji dla desktopu i mobile.